### PR TITLE
KTOR-4415 Downgrade ShadowJar Plugin to v5

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -11,6 +11,7 @@ val kotlin_version: String by project
 val junit_version: String by project
 val shadow_plugin_version: String by project
 val jib_gradle_plugin_version: String by project
+val log4j_version: String by project
 
 object PluginCoordinates {
     const val ID = "io.ktor.ktor-gradle-plugin"
@@ -98,6 +99,15 @@ publishing {
         maven {
             name = "localPluginRepository"
             url = uri("../local-plugin-repository")
+        }
+    }
+}
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.apache.logging.log4j") {
+            useVersion(log4j_version)
+            because("zero-day exploit, required for Shadow v5")
         }
     }
 }

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -2,3 +2,4 @@ kotlin_version=1.6.21
 junit_version=5.8.2
 shadow_plugin_version=5.2.0
 jib_gradle_plugin_version=3.2.1
+log4j_version=2.17.2


### PR DESCRIPTION
The lower ShadowJar plugin version is used, the more versions of Gradle we can support. Dropping lower than Gradle v5 is painful, but using v5 is okay and it will allow users to use Ktor Plugin with Gradle starting with v5.