### PR TITLE
KTOR-4568 `publishImage` throws 401 while credentials are correct

### DIFF
--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
@@ -143,6 +143,11 @@ private fun markJibTaskNotCompatible(task: Task) = task.notCompatibleWithConfigu
 )
 
 private abstract class ConfigureJibTaskBase(@get:Input val isExternal: Boolean) : DefaultTask() {
+    init {
+        @Suppress("LeakingThis")
+        markJibTaskNotCompatible(this)
+    }
+
     @TaskAction
     fun execute() {
         val jibExtension = project.extensions.getByType(JibExtension::class.java)


### PR DESCRIPTION
JIB plugin is not ready for the configuration cache and loads tasks eagerly. To avoid errors with that, we can do all the work in the execution time instead of configuration time. This way we will only configure tasks that are part of the build.