### PR TITLE
KTOR-4569 GraalVM agent enabling does not work

### DIFF
--- a/plugin/gradle/libs.versions.toml
+++ b/plugin/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ logback = "1.2.11"
 gradle-plugin-publish = "1.0.0-rc-3"
 shadow-gradle-plugin = "6.1.0"
 jib-gradle-plugin = "3.2.1"
-graalvm-gradle-plugin = "0.9.12"
+graalvm-gradle-plugin = "0.9.11"
 junit = "5.8.2"
 log4j = "2.17.2" # To replace vulnerable versions
 


### PR DESCRIPTION
After upgrading graalvm plugin to `0.9.12`, agent enabling stopped working. The issue seem to be in the new version of the plugin: https://github.com/graalvm/native-build-tools/issues/254
Proposed solution is to downgrade to `0.9.11` and reopen KTOR-4477.