### PR TITLE
KTOR-4775 Mark task's GCC incompatibility only with Gradle v7.4+

### DIFF
--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
@@ -153,8 +153,7 @@ const val RUN_DOCKER_TASK_NAME = "runDocker"
 private const val SETUP_JIB_LOCAL_TASK_NAME = "setupJibLocal"
 private const val SETUP_JIB_EXTERNAL_TASK_NAME = "setupJibExternal"
 
-@Suppress("UnstableApiUsage")
-private fun markJibTaskNotCompatible(task: Task) = task.notCompatibleWithConfigurationCache(
+private fun markJibTaskNotCompatible(task: Task) = task.markNotCompatibleWithConfigurationCache(
     "JIB plugin is not compatible with the configuration cache. " +
             "See https://github.com/GoogleContainerTools/jib/issues/3132"
 )

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
@@ -4,7 +4,6 @@ import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.tasks.TaskContainer
 
@@ -39,14 +38,6 @@ private fun configureMainClass(project: Project) {
     application.mainClassName = mainClassName
 }
 
-@Suppress("UnstableApiUsage")
-private fun Task.shadowTaskIsNotCompatibleWithConfigurationCache(taskName: String) {
-    notCompatibleWithConfigurationCache(
-        "`$taskName` is not compatible yet: " +
-                "https://github.com/johnrengelman/shadow/issues/775"
-    )
-}
-
 private val INCOMPATIBLE_SHADOW_TASK_NAMES = arrayOf(
     SHADOW_INSTALL_TASK_NAME,
     SHADOW_RUN_TASK_NAME
@@ -55,7 +46,10 @@ private val INCOMPATIBLE_SHADOW_TASK_NAMES = arrayOf(
 private fun markShadowTasksAsNotCompatibleWithConfigurationCache(tasks: TaskContainer) {
     INCOMPATIBLE_SHADOW_TASK_NAMES.forEach { taskName ->
         tasks.named(taskName) {
-            it.shadowTaskIsNotCompatibleWithConfigurationCache(taskName)
+            it.markNotCompatibleWithConfigurationCache(
+                "`$taskName` is not compatible with Gradle Configuration Cache yet: " +
+                        "https://github.com/johnrengelman/shadow/issues/775"
+            )
         }
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Ktor.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Ktor.kt
@@ -10,6 +10,7 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.util.GradleVersion
 
 const val KTOR_TASK_GROUP_NAME = "Ktor"
 
@@ -55,3 +56,10 @@ inline fun <reified T> Project.property(defaultValue: T?): Property<T> =
     objects.property(T::class.java).convention(defaultValue)
 
 val Project.javaVersion: JavaVersion get() = extensions.getByType(JavaPluginExtension::class.java).targetCompatibility
+
+fun Task.markNotCompatibleWithConfigurationCache(reason: String) {
+    if (GradleVersion.current() >= GradleVersion.version("7.4")) {
+        @Suppress("UnstableApiUsage")
+        notCompatibleWithConfigurationCache(reason)
+    }
+}

--- a/plugin/src/test/kotlin/io/ktor/plugin/GradleVersionCompatibilityTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/GradleVersionCompatibilityTest.kt
@@ -4,24 +4,40 @@ import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
+import kotlin.test.Test
 
 class GradleVersionCompatibilityTest {
-    private fun buildProject(gradleVersion: String, projectDir: File, expectSuccess: Boolean) {
+    @ParameterizedTest
+    @ValueSource(strings = ["6.7", "7.3.3", "7.5.1"])
+    fun testProjectBuild(gradleVersion: String, @TempDir projectDir: File) {
         projectDir.resolve("build.gradle").writeText("plugins { id 'io.ktor.plugin' }")
         createGradleRunner(projectDir)
             .withGradleVersion(gradleVersion)
-            .run { if (expectSuccess) build() else buildAndFail() }
+            .build()
     }
 
-    @ParameterizedTest
-    @ValueSource(
-        strings = [
-            "6.7",
-//            "6.7.1", "6.8", "6.8.1", "6.8.2", "6.8.3", "6.9", "6.9.1", "6.9.2",
-//            "7.0", "7.0.1", "7.0.2", "7.1", "7.1.1", "7.2", "7.3", "7.3.1", "7.3.2", "7.3.3", "7.4", "7.4.1",
-            "7.4.2"
-        ]
-    )
-    fun testProjectBuild(gradleVersion: String, @TempDir projectDir: File) =
-        buildProject(gradleVersion, projectDir, true)
+    @Test
+    fun `test not fails when gradle is old and task is not GCC compatible`(@TempDir projectDir: File) {
+        val gradleVersion = "7.3.3" // any version lower than 7.4
+
+        // any incompatible with Gradle Configuration Cache task, see https://github.com/johnrengelman/shadow/issues/775
+        val incompatibleTask = "runShadow"
+
+        buildProject(
+            projectDir = projectDir,
+            buildGradleKtsContent = """
+                plugins {
+                    kotlin("jvm") version "1.7.0"
+                    id("io.ktor.plugin")
+                }
+                repositories.mavenCentral()
+                application.mainClass.set("my.org.MainKt")
+            """.trimIndent(),
+            settingsGradleKtsContent = "",
+            mainKtContent = "package my.org\nfun main() {}",
+            buildCommand = incompatibleTask,
+            expectSuccess = true,
+            gradleVersion = gradleVersion
+        )
+    }
 }


### PR DESCRIPTION
This will allow using the plugin in projects with Gradle version lower than v7.4 without runtime exceptions like MethodNotFoundException