### PR TITLE
Add a property to enable development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,35 @@ The format is based on Keep a Changelog: https://keepachangelog.com/en/1.1.0/
 
 *No changes yet*
 
+## [3.1.0] - 2025-02-12
+
+- Update Ktor to [v3.1.0](https://github.com/ktorio/ktor/releases/tag/3.1.0)
+- Update Shadow plugin to v8.3.6 
+- Update Gradle plugin for GraalVM Native Image to v0.10.5
+- Update Gradle to v8.12.1
+
+## [3.0.3] - 2024-12-19
+
+- Update Ktor to [v3.0.3](https://github.com/ktorio/ktor/releases/tag/3.0.3)
+
+## [3.0.2] - 2024-12-04
+
+- Update Ktor to [v3.0.2](https://github.com/ktorio/ktor/releases/tag/3.0.2)
+- Update Shadow plugin to v8.3.5
+
 ## [3.0.1] - 2024-10-30
 
 > [!WARNING]
 > The minimal supported Gradle version now is 8.3 as it is required for the Shadow plugin
 
+- Update Ktor to [v3.0.1](https://github.com/ktorio/ktor/releases/tag/3.0.1)
 - Update Shadow plugin to v8.3.4 ([KTOR-7228](https://youtrack.jetbrains.com/issue/KTOR-7228), [KTOR-6107](https://youtrack.jetbrains.com/issue/KTOR-6107))
 - Bump minimal required JVM to run Gradle from 8 to 11 (as it is required for jib plugin)
 - Bump default JRE in Docker to 21 (current LTS version)
 - Set Kotlin API and language level to 1.8 for compatibility with Gradle 8.0+
 
-[unreleased]: https://github.com/ktorio/ktor-build-plugins/compare/v3.0.1...main
+[unreleased]: https://github.com/ktorio/ktor-build-plugins/compare/v3.1.0...main
+[3.1.0]: https://github.com/ktorio/ktor-build-plugins/compare/v3.0.3...v3.1.0
+[3.0.3]: https://github.com/ktorio/ktor-build-plugins/compare/v3.0.2...v3.0.3
+[3.0.2]: https://github.com/ktorio/ktor-build-plugins/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/ktorio/ktor-build-plugins/compare/v3.0.0...v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ The format is based on Keep a Changelog: https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
-*No changes yet*
+- [KTOR-8173] Add property `ktor.development` to simplify development mode enabling
+
+[KTOR-8173]: https://youtrack.jetbrains.com/issue/KTOR-8173/
 
 ## [3.1.0] - 2025-02-12
 

--- a/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
@@ -1,17 +1,20 @@
 package io.ktor.plugin
 
 import io.ktor.plugin.features.*
+import io.ktor.plugin.features.KtorExtension.Companion.DEVELOPMENT_MODE_PROPERTY
+import io.ktor.plugin.internal.*
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ApplicationPlugin
+import org.gradle.api.plugins.JavaApplication
 
 const val KTOR_VERSION = "3.1.0"
 
 @Suppress("unused") // Gradle Plugin is not used directly
 abstract class KtorGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) = with(project) {
-        extensions.create(KtorExtension.NAME, KtorExtension::class.java)
-        configureApplication()
+        val extension = extensions.create(KtorExtension.NAME, KtorExtension::class.java)
+        configureApplication(extension)
         configureFatJar()
         configureDocker()
         configureBomFile()
@@ -20,7 +23,18 @@ abstract class KtorGradlePlugin : Plugin<Project> {
         // configureNativeImage()
     }
 
-    private fun Project.configureApplication() {
+    private fun Project.configureApplication(extension: KtorExtension) {
         plugins.apply(ApplicationPlugin::class.java)
+
+        afterEvaluate {
+            if (extension.development.get()) application.enableDevelopmentMode()
+        }
+    }
+}
+
+private fun JavaApplication.enableDevelopmentMode() {
+    val prefix = "-D$DEVELOPMENT_MODE_PROPERTY="
+    if (applicationDefaultJvmArgs.none { it.startsWith(prefix) }) {
+        applicationDefaultJvmArgs += "${prefix}true"
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
@@ -9,13 +9,18 @@ const val KTOR_VERSION = "3.1.0"
 
 @Suppress("unused") // Gradle Plugin is not used directly
 abstract class KtorGradlePlugin : Plugin<Project> {
-    override fun apply(project: Project) {
-        project.plugins.apply(ApplicationPlugin::class.java)
-        configureFatJar(project)
-        configureDocker(project)
-        configureBomFile(project)
+    override fun apply(project: Project) = with(project) {
+        extensions.create(KtorExtension.NAME, KtorExtension::class.java)
+        configureApplication()
+        configureFatJar()
+        configureDocker()
+        configureBomFile()
         // Disabled until the native image generation is not possible with a single task with default configs
         // See https://youtrack.jetbrains.com/issue/KTOR-4596/Disable-Native-image-related-tasks
-        // configureNativeImage(project)
+        // configureNativeImage()
+    }
+
+    private fun Project.configureApplication() {
+        plugins.apply(ApplicationPlugin::class.java)
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/BomFile.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/BomFile.kt
@@ -3,8 +3,8 @@ package io.ktor.plugin.features
 import io.ktor.plugin.*
 import org.gradle.api.Project
 
-fun configureBomFile(project: Project) {
-    with(project.dependencies) {
+internal fun Project.configureBomFile() {
+    with(dependencies) {
         add("implementation", platform("io.ktor:ktor-bom:$KTOR_VERSION"))
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
@@ -284,10 +284,9 @@ private abstract class RunDockerTask : DefaultTask() {
     }
 }
 
-fun configureDocker(project: Project) {
-    project.plugins.apply(JibPlugin::class.java)
-    val dockerExtension = project.createKtorExtension<DockerExtension>(DOCKER_EXTENSION_NAME)
-    val tasks = project.tasks
+internal fun Project.configureDocker() {
+    plugins.apply(JibPlugin::class.java)
+    val dockerExtension = createKtorExtension<DockerExtension>(DOCKER_EXTENSION_NAME)
 
     tasks.withType(JibTask::class.java).configureEach { markJibTaskNotCompatible(it) }
 

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
@@ -25,11 +25,10 @@ private const val RUN_FAT_JAR_TASK_DESCRIPTION =
 private const val SHADOW_RUN_TASK_NAME = "runShadow"
 private const val SHADOW_JAR_TASK_NAME = "shadowJar"
 
-fun configureFatJar(project: Project) {
-    project.plugins.apply(ShadowPlugin::class.java)
-    val tasks = project.tasks
+internal fun Project.configureFatJar() {
+    plugins.apply(ShadowPlugin::class.java)
 
-    val fatJarExtension = project.createKtorExtension<FatJarExtension>(FAT_JAR_EXTENSION_NAME)
+    val fatJarExtension = createKtorExtension<FatJarExtension>(FAT_JAR_EXTENSION_NAME)
     val shadowJar: TaskProvider<ShadowJar> = tasks.named(SHADOW_JAR_TASK_NAME, ShadowJar::class.java) {
         it.archiveFileName.set(fatJarExtension.archiveFileName)
         it.isZip64 = fatJarExtension.allowZip64.get()

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/Accessors.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/Accessors.kt
@@ -1,0 +1,11 @@
+package io.ktor.plugin.internal
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaApplication
+
+internal val Project.application: JavaApplication
+    get() = extensions.getByType(JavaApplication::class.java)
+
+internal fun Project.application(configure: JavaApplication.() -> Unit) {
+    extensions.configure(JavaApplication::class.java, configure)
+}

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/Properties.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/Properties.kt
@@ -1,0 +1,8 @@
+package io.ktor.plugin.internal
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+
+internal fun <T> Property<T>.finalizedOnRead(): Property<T> = apply { finalizeValueOnRead() }
+
+internal fun Provider<String>.toBoolean(): Provider<Boolean> = map { it.toBoolean() }.orElse(false)

--- a/plugin/src/test/kotlin/io/ktor/plugin/Accessors.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/Accessors.kt
@@ -1,0 +1,8 @@
+package io.ktor.plugin
+
+import io.ktor.plugin.features.*
+import org.gradle.api.Project
+
+internal fun Project.ktor(configure: KtorExtension.() -> Unit) {
+    extensions.configure(KtorExtension::class.java, configure)
+}

--- a/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
@@ -2,15 +2,20 @@ package io.ktor.plugin
 
 import io.ktor.plugin.features.*
 import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 
-fun Project.applyPlugin(configureExt: KtorExtension.() -> Unit = {}) {
+internal fun Project.applyPlugin(configureExt: KtorExtension.() -> Unit = {}) {
     project.plugins.apply(KtorGradlePlugin::class.java)
     project.extensions.configure(KtorExtension::class.java) { ext ->
         ext.configureExt()
     }
 }
 
-fun createGradleRunner(projectDir: File): GradleRunner =
+internal fun Project.evaluate() {
+    (this as ProjectInternal).evaluate()
+}
+
+internal fun createGradleRunner(projectDir: File): GradleRunner =
     GradleRunner.create().withProjectDir(projectDir).withPluginClasspath()


### PR DESCRIPTION
Fixes [KTOR-8173](https://youtrack.jetbrains.com/issue/KTOR-8173) "Support enabling development mode from the CLI"

Added a property to enable development mode from our Gradle plugin. By default, development mode is enabled if Gradle property or system property with the name "io.ktor.development" is set to `true`.

