### PR TITLE
KTOR-8444: Basic compatibility with KMP 2.1.20+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ The format is based on Keep a Changelog: https://keepachangelog.com/en/1.1.0/
 
 ## [Unreleased]
 
-_No changes yet_
+- [KTOR-8444] Basic compatibility with the Kotlin Multiplatform Gradle plugin
+- [KTOR-8419] Do not apply Gradle's Application plugin for KMP projects
+
+[KTOR-8444]: https://youtrack.jetbrains.com/issue/KTOR-8444/
+[KTOR-8419]: https://youtrack.jetbrains.com/issue/KTOR-8419/
 
 ## [3.1.3] - 2025-05-05
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ mockk = "1.14.2"
 
 [libraries]
 kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
+gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradlePlugin-shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "gradlePlugin-shadow" }
 gradlePlugin-jib = { module = "com.google.cloud.tools:jib-gradle-plugin", version.ref = "gradlePlugin-jib" }
 gradlePlugin-graalvm = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "gradlePlugin-graalvm" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -17,10 +17,12 @@ if (hasProperty("versionSuffix")) {
 dependencies {
     implementation(gradleApi())
 
+    compileOnly(libs.gradlePlugin.kotlin)
     implementation(libs.gradlePlugin.shadow)
     implementation(libs.gradlePlugin.jib)
     implementation(libs.gradlePlugin.graalvm)
 
+    testImplementation(libs.gradlePlugin.kotlin)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.junit.jupiter.params)

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -79,9 +79,14 @@ tasks.named("publishPlugins") {
     dependsOn("test", setupPluginUploadFromEnvironment)
 }
 
-tasks.withType<Test> {
+val publishToMavenLocal = tasks.named("publishToMavenLocal")
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     testLogging.events(*TestLogEvent.values())
+
+    // The plugin should be published to MavenLocal to be available in integration tests
+    // We can't use GradleRunner.withPluginClasspath() because of https://github.com/gradle/gradle/issues/22466
+    dependsOn(publishToMavenLocal)
 }
 
 if (hasProperty("space")) {

--- a/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
@@ -34,23 +34,23 @@ abstract class KtorGradlePlugin : Plugin<Project> {
     }
 
     private fun Project.reportKmpCompatibilityWarning() {
-        logger.warn("warning: Ktor Gradle plugin is not fully compatible with Kotlin Multiplatform plugin.")
+        logger.warn("warning: The Ktor Gradle plugin is not fully compatible with the Kotlin Multiplatform plugin.")
         logger.lifecycle(
             """
             |
-            |Building fat JAR and Docker image for Ktor application is not supported when the plugin applied to a multiplatform project.
-            |As a workaround, create a JVM-only project with Ktor plugin applied and add the multiplatform project as a dependency to it.
-            |Let us know about your use case in the issue: https://youtrack.jetbrains.com/issue/KTOR-8464
+            |Building a fat JAR or a Docker image for a Ktor application is not supported when the plugin is applied to a multiplatform project.
+            |As a workaround, create a JVM-only project with the Ktor plugin applied and add the multiplatform project as a dependency.
+            |If this limitation affects your use case, let us know by commenting on the issue: https://youtrack.jetbrains.com/issue/KTOR-8464
             |
             """.trimMargin()
         )
     }
 
     private fun Project.reportKotlinPluginMissingWarning() {
-        logger.warn("warning: Ktor Gradle plugin cannot be used without Kotlin Gradle plugin.")
+        logger.warn("warning: The Ktor Gradle plugin requires the Kotlin Gradle plugin.")
         logger.lifecycle(
             """
-            |Please, apply Kotlin Gradle plugin to the project:
+            |To fix this, apply the Kotlin Gradle plugin to your project:
             |
             |  plugins {
             |      kotlin("jvm")

--- a/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/KtorGradlePlugin.kt
@@ -1,12 +1,8 @@
 package io.ktor.plugin
 
 import io.ktor.plugin.features.*
-import io.ktor.plugin.features.KtorExtension.Companion.DEVELOPMENT_MODE_PROPERTY
-import io.ktor.plugin.internal.*
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.ApplicationPlugin
-import org.gradle.api.plugins.JavaApplication
 
 const val KTOR_VERSION = "3.1.3"
 
@@ -14,27 +10,12 @@ const val KTOR_VERSION = "3.1.3"
 abstract class KtorGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = project.extensions.create(KtorExtension.NAME, KtorExtension::class.java)
-        configureApplication(project, extension)
+        project.configureApplication(extension)
         configureFatJar(project)
         configureDocker(project)
         configureBomFile(project)
         // Disabled until the native image generation is not possible with a single task with default configs
         // See https://youtrack.jetbrains.com/issue/KTOR-4596/Disable-Native-image-related-tasks
         // configureNativeImage(project)
-    }
-
-    private fun configureApplication(project: Project, extension: KtorExtension) = with(project) {
-        plugins.apply(ApplicationPlugin::class.java)
-
-        afterEvaluate {
-            if (extension.development.get()) application.enableDevelopmentMode()
-        }
-    }
-}
-
-private fun JavaApplication.enableDevelopmentMode() {
-    val prefix = "-D$DEVELOPMENT_MODE_PROPERTY="
-    if (applicationDefaultJvmArgs.none { it.startsWith(prefix) }) {
-        applicationDefaultJvmArgs += "${prefix}true"
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/ApplicationConfiguration.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/ApplicationConfiguration.kt
@@ -1,0 +1,61 @@
+package io.ktor.plugin.features
+
+import io.ktor.plugin.features.KtorExtension.Companion.DEVELOPMENT_MODE_PROPERTY
+import io.ktor.plugin.internal.*
+import org.gradle.api.Project
+import org.gradle.api.plugins.ApplicationPlugin
+import org.gradle.api.plugins.ApplicationPlugin.APPLICATION_GROUP
+import org.gradle.api.tasks.JavaExec
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+
+internal fun Project.configureApplication(extension: KtorExtension) {
+    whenKotlinJvmApplied {
+        configureJvmApplication(extension)
+    }
+
+    whenKotlinMultiplatformApplied {
+        if (KotlinVersion.parse(getKotlinPluginVersion()) < KotlinVersion.V2_1_20) {
+            configureJvmApplication(extension)
+        } else {
+            configureMultiplatformApplication(extension)
+        }
+    }
+}
+
+private fun Project.configureJvmApplication(extension: KtorExtension) {
+    plugins.apply<ApplicationPlugin>()
+
+    afterEvaluate {
+        if (extension.development.get()) {
+            application {
+                applicationDefaultJvmArgs = applicationDefaultJvmArgs.withDevelopmentModeEnabled()
+            }
+        }
+    }
+}
+
+private fun Project.configureMultiplatformApplication(extension: KtorExtension) {
+    tasks.configureEach<JavaExec> { task ->
+        val developmentModeArgument = provider {
+            val shouldAddArgument = task.isAddedByKotlinPlugin() && extension.development.get()
+            if (shouldAddArgument) listOf(DEVELOPMENT_MODE_ENABLED) else emptyList()
+        }
+        task.jvmArguments.addAll(developmentModeArgument)
+    }
+}
+
+// See org.jetbrains.kotlin.gradle.targets.jvm.DefaultKotlinJvmBinariesDsl implementation
+private fun JavaExec.isAddedByKotlinPlugin(): Boolean {
+    return group == APPLICATION_GROUP && description?.startsWith("Run Kotlin") == true
+}
+
+private const val DEVELOPMENT_MODE_PREFIX = "-D$DEVELOPMENT_MODE_PROPERTY="
+private const val DEVELOPMENT_MODE_ENABLED = DEVELOPMENT_MODE_PREFIX + "true"
+
+private fun Iterable<String>.withDevelopmentModeEnabled(): Iterable<String> {
+    return if (none { it.startsWith(DEVELOPMENT_MODE_PREFIX) }) {
+        this + DEVELOPMENT_MODE_ENABLED
+    } else {
+        this
+    }
+}

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/ApplicationConfiguration.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/ApplicationConfiguration.kt
@@ -23,7 +23,7 @@ internal fun Project.configureApplication(extension: KtorExtension) {
 }
 
 private fun Project.configureJvmApplication(extension: KtorExtension) {
-    plugins.apply<ApplicationPlugin>()
+    apply<ApplicationPlugin>()
 
     afterEvaluate {
         if (extension.development.get()) {

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/BomFile.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/BomFile.kt
@@ -2,6 +2,7 @@ package io.ktor.plugin.features
 
 import io.ktor.plugin.*
 import io.ktor.plugin.internal.*
+import io.ktor.plugin.internal.KotlinPluginType.*
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
@@ -9,15 +10,22 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
 fun configureBomFile(project: Project) = with(project) {
-    whenKotlinJvmApplied {
-        dependencies.add("implementation", dependencies.ktorBom)
+    whenKotlinPluginApplied { pluginType ->
+        when (pluginType) {
+            JVM -> configureJvmDependency()
+            Multiplatform -> configureMultiplatformDependency()
+        }
     }
+}
 
-    whenKotlinMultiplatformApplied {
-        with(kotlinExtension as KotlinMultiplatformExtension) {
-            sourceSets.commonMain.dependencies {
-                implementation(dependencies.ktorBom)
-            }
+private fun Project.configureJvmDependency() {
+    dependencies.add("implementation", dependencies.ktorBom)
+}
+
+private fun Project.configureMultiplatformDependency() {
+    with(kotlinExtension as KotlinMultiplatformExtension) {
+        sourceSets.commonMain.dependencies {
+            implementation(dependencies.ktorBom)
         }
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/BomFile.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/BomFile.kt
@@ -1,10 +1,26 @@
 package io.ktor.plugin.features
 
 import io.ktor.plugin.*
+import io.ktor.plugin.internal.*
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
-fun configureBomFile(project: Project) {
-    with(project.dependencies) {
-        add("implementation", platform("io.ktor:ktor-bom:$KTOR_VERSION"))
+fun configureBomFile(project: Project) = with(project) {
+    whenKotlinJvmApplied {
+        dependencies.add("implementation", dependencies.ktorBom)
+    }
+
+    whenKotlinMultiplatformApplied {
+        with(kotlinExtension as KotlinMultiplatformExtension) {
+            sourceSets.commonMain.dependencies {
+                implementation(dependencies.ktorBom)
+            }
+        }
     }
 }
+
+private val DependencyHandler.ktorBom: Dependency
+    get() = platform("io.ktor:ktor-bom:$KTOR_VERSION")

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
@@ -4,6 +4,7 @@ import com.google.cloud.tools.jib.gradle.JibExtension
 import com.google.cloud.tools.jib.gradle.JibPlugin
 import com.google.cloud.tools.jib.gradle.JibTask
 import com.google.cloud.tools.jib.gradle.TargetImageParameters
+import io.ktor.plugin.internal.*
 import org.gradle.api.*
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -284,12 +285,24 @@ private abstract class RunDockerTask : DefaultTask() {
     }
 }
 
-fun configureDocker(project: Project) {
-    project.plugins.apply(JibPlugin::class.java)
-    val dockerExtension = project.createKtorExtension<DockerExtension>(DOCKER_EXTENSION_NAME)
-    val tasks = project.tasks
+fun configureDocker(project: Project) = with(project) {
+    val dockerExtension = createKtorExtension<DockerExtension>(DOCKER_EXTENSION_NAME)
 
-    tasks.withType(JibTask::class.java).configureEach { markJibTaskNotCompatible(it) }
+    // Apply JIB plugin only when the Kotlin JVM plugin is applied.
+    // TODO: JIB uses hardcoded "main" source set, it makes it incompatible with KMP
+    //   https://github.com/GoogleContainerTools/jib/issues/4316
+    whenKotlinJvmApplied {
+        plugins.apply<JibPlugin>()
+    }
+
+    // By using `withPlugin` we handle the case when a user explicitly applies JIB plugin in a KMP project.
+    plugins.withId(JIB_PLUGIN_ID) {
+        configureJibPlugin(dockerExtension)
+    }
+}
+
+private fun Project.configureJibPlugin(dockerExtension: DockerExtension) {
+    tasks.configureEach<JibTask> { markJibTaskNotCompatible(it) }
 
     val configureJibLocalTask = tasks.register(SETUP_JIB_LOCAL_TASK_NAME, ConfigureJibLocalTask::class.java)
     val configureJibExternalTask = tasks.register(SETUP_JIB_EXTERNAL_TASK_NAME, ConfigureJibExternalTask::class.java)

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
@@ -292,11 +292,11 @@ fun configureDocker(project: Project) = with(project) {
     // TODO: JIB uses hardcoded "main" source set, it makes it incompatible with KMP
     //   https://github.com/GoogleContainerTools/jib/issues/4316
     whenKotlinJvmApplied {
-        plugins.apply<JibPlugin>()
+        apply<JibPlugin>()
     }
 
     // By using `withPlugin` we handle the case when a user explicitly applies JIB plugin in a KMP project.
-    plugins.withId(JIB_PLUGIN_ID) {
+    pluginManager.withPlugin(JIB_PLUGIN_ID) {
         configureJibPlugin(dockerExtension)
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
@@ -2,7 +2,9 @@ package io.ktor.plugin.features
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import io.ktor.plugin.internal.*
 import org.gradle.api.Project
+import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.tasks.TaskProvider
 
 abstract class FatJarExtension(project: Project) {
@@ -25,11 +27,23 @@ private const val RUN_FAT_JAR_TASK_DESCRIPTION =
 private const val SHADOW_RUN_TASK_NAME = "runShadow"
 private const val SHADOW_JAR_TASK_NAME = "shadowJar"
 
-fun configureFatJar(project: Project) {
-    project.plugins.apply(ShadowPlugin::class.java)
-    val tasks = project.tasks
+fun configureFatJar(project: Project) = with(project) {
+    val fatJarExtension = createKtorExtension<FatJarExtension>(FAT_JAR_EXTENSION_NAME)
 
-    val fatJarExtension = project.createKtorExtension<FatJarExtension>(FAT_JAR_EXTENSION_NAME)
+    // Apply Shadow plugin only when the application plugin is applied.
+    // TODO: KMP support will be added in Shadow 9.0.0
+    //   https://github.com/GradleUp/shadow/pull/1333
+    plugins.withId(ApplicationPlugin.APPLICATION_PLUGIN_NAME) {
+        plugins.apply<ShadowPlugin>()
+    }
+
+    // By using `withId` we handle the case when a user explicitly applies Shadow plugin.
+    plugins.withId(SHADOW_PLUGIN_ID) {
+        configureShadowPlugin(fatJarExtension)
+    }
+}
+
+private fun Project.configureShadowPlugin(fatJarExtension: FatJarExtension) {
     val shadowJar: TaskProvider<ShadowJar> = tasks.named(SHADOW_JAR_TASK_NAME, ShadowJar::class.java) {
         it.archiveFileName.set(fatJarExtension.archiveFileName)
         it.isZip64 = fatJarExtension.allowZip64.get()

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/FatJar.kt
@@ -33,12 +33,12 @@ fun configureFatJar(project: Project) = with(project) {
     // Apply Shadow plugin only when the application plugin is applied.
     // TODO: KMP support will be added in Shadow 9.0.0
     //   https://github.com/GradleUp/shadow/pull/1333
-    plugins.withId(ApplicationPlugin.APPLICATION_PLUGIN_NAME) {
-        plugins.apply<ShadowPlugin>()
+    pluginManager.withPlugin(ApplicationPlugin.APPLICATION_PLUGIN_NAME) {
+        apply<ShadowPlugin>()
     }
 
-    // By using `withId` we handle the case when a user explicitly applies Shadow plugin.
-    plugins.withId(SHADOW_PLUGIN_ID) {
+    // By using `withPlugin` we handle the case when a user explicitly applies Shadow plugin.
+    pluginManager.withPlugin(SHADOW_PLUGIN_ID) {
         configureShadowPlugin(fatJarExtension)
     }
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/NativeImage.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/NativeImage.kt
@@ -1,5 +1,6 @@
 package io.ktor.plugin.features
 
+import io.ktor.plugin.internal.*
 import org.graalvm.buildtools.gradle.NativeImagePlugin
 import org.graalvm.buildtools.gradle.dsl.GraalVMExtension
 import org.graalvm.buildtools.gradle.dsl.GraalVMReachabilityMetadataRepositoryExtension
@@ -84,9 +85,9 @@ private fun configureGraalVM(project: Project, nativeImageExtension: NativeImage
     }
 }
 
-fun configureNativeImage(project: Project) {
-    project.plugins.apply(JavaPlugin::class.java) // required for NativeImagePlugin
-    project.plugins.apply(NativeImagePlugin::class.java)
+fun configureNativeImage(project: Project) = with(project) {
+    apply<JavaPlugin>() // required for NativeImagePlugin
+    apply<NativeImagePlugin>()
 
     val nativeImageExtension = project.createKtorExtension<NativeImageExtension>(NATIVE_IMAGE_EXTENSION_NAME)
     val configureGraalVMTask = project.tasks.register(CONFIGURE_GRAALVM_TASK_NAME) {

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/Constants.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/Constants.kt
@@ -2,3 +2,4 @@ package io.ktor.plugin.internal
 
 internal const val KOTLIN_JVM_PLUGIN_ID = "org.jetbrains.kotlin.jvm"
 internal const val KMP_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"
+internal const val SHADOW_PLUGIN_ID = "com.gradleup.shadow"

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/Constants.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/Constants.kt
@@ -1,0 +1,4 @@
+package io.ktor.plugin.internal
+
+internal const val KOTLIN_JVM_PLUGIN_ID = "org.jetbrains.kotlin.jvm"
+internal const val KMP_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/Constants.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/Constants.kt
@@ -3,3 +3,4 @@ package io.ktor.plugin.internal
 internal const val KOTLIN_JVM_PLUGIN_ID = "org.jetbrains.kotlin.jvm"
 internal const val KMP_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"
 internal const val SHADOW_PLUGIN_ID = "com.gradleup.shadow"
+internal const val JIB_PLUGIN_ID = "com.google.cloud.tools.jib"

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/GradleDsl.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/GradleDsl.kt
@@ -1,0 +1,16 @@
+package io.ktor.plugin.internal
+
+import org.gradle.api.Action
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.Plugin
+import org.gradle.api.plugins.PluginContainer
+
+internal inline fun <reified T : Plugin<*>> PluginContainer.apply(): T = apply(T::class.java)
+
+internal inline fun <reified T> DomainObjectCollection<in T>.withType(): DomainObjectCollection<T> {
+    return withType(T::class.java)
+}
+
+internal inline fun <reified T> DomainObjectCollection<in T>.configureEach(configure: Action<T>) {
+    withType(T::class.java).configureEach(configure)
+}

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/GradleDsl.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/GradleDsl.kt
@@ -3,9 +3,9 @@ package io.ktor.plugin.internal
 import org.gradle.api.Action
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
-import org.gradle.api.plugins.PluginContainer
+import org.gradle.api.Project
 
-internal inline fun <reified T : Plugin<*>> PluginContainer.apply(): T = apply(T::class.java)
+internal inline fun <reified T : Plugin<*>> Project.apply() = pluginManager.apply(T::class.java)
 
 internal inline fun <reified T> DomainObjectCollection<in T>.withType(): DomainObjectCollection<T> {
     return withType(T::class.java)

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/KotlinVersion.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/KotlinVersion.kt
@@ -1,0 +1,25 @@
+package io.ktor.plugin.internal
+
+@JvmInline
+internal value class KotlinVersion(private val value: Int) : Comparable<KotlinVersion> {
+    private val major: Int get() = value / 1_0_00
+    private val minor: Int get() = (value / 1_00) % 10
+    private val patch: Int get() = value % 100
+
+    override fun toString(): String = "$major.$minor.$patch"
+    override fun compareTo(other: KotlinVersion): Int = value.compareTo(other.value)
+
+    companion object {
+        fun parse(version: String): KotlinVersion {
+            val versionParts = version
+                .substringBefore("-")
+                .split('.').mapNotNull { it.toIntOrNull() }
+            require(versionParts.size == 3) { "Unable to parse Kotlin version '$version'." }
+
+            val (major, minor, patch) = versionParts
+            return KotlinVersion(major * 1_0_00 + minor * 1_00 + patch)
+        }
+
+        val V2_1_20 = KotlinVersion(2_1_20)
+    }
+}

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/WhenPluginApplied.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/WhenPluginApplied.kt
@@ -1,0 +1,11 @@
+package io.ktor.plugin.internal
+
+import org.gradle.api.Project
+
+internal fun Project.whenKotlinMultiplatformApplied(block: () -> Unit) {
+    plugins.withId(KMP_PLUGIN_ID) { block() }
+}
+
+internal fun Project.whenKotlinJvmApplied(block: () -> Unit) {
+    plugins.withId(KOTLIN_JVM_PLUGIN_ID) { block() }
+}

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/WhenPluginApplied.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/WhenPluginApplied.kt
@@ -2,10 +2,22 @@ package io.ktor.plugin.internal
 
 import org.gradle.api.Project
 
+internal fun Project.whenKotlinPluginApplied(
+    block: (KotlinPluginType) -> Unit,
+) {
+    whenKotlinJvmApplied { block(KotlinPluginType.JVM) }
+    whenKotlinMultiplatformApplied { block(KotlinPluginType.Multiplatform) }
+}
+
 internal fun Project.whenKotlinMultiplatformApplied(block: () -> Unit) {
     pluginManager.withPlugin(KMP_PLUGIN_ID) { block() }
 }
 
 internal fun Project.whenKotlinJvmApplied(block: () -> Unit) {
     pluginManager.withPlugin(KOTLIN_JVM_PLUGIN_ID) { block() }
+}
+
+internal enum class KotlinPluginType {
+    JVM,
+    Multiplatform,
 }

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/WhenPluginApplied.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/WhenPluginApplied.kt
@@ -3,9 +3,9 @@ package io.ktor.plugin.internal
 import org.gradle.api.Project
 
 internal fun Project.whenKotlinMultiplatformApplied(block: () -> Unit) {
-    plugins.withId(KMP_PLUGIN_ID) { block() }
+    pluginManager.withPlugin(KMP_PLUGIN_ID) { block() }
 }
 
 internal fun Project.whenKotlinJvmApplied(block: () -> Unit) {
-    plugins.withId(KOTLIN_JVM_PLUGIN_ID) { block() }
+    pluginManager.withPlugin(KOTLIN_JVM_PLUGIN_ID) { block() }
 }

--- a/plugin/src/test/kotlin/io/ktor/plugin/DockerTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/DockerTest.kt
@@ -19,7 +19,7 @@ class DockerTest {
     @Test
     fun `cannot build an image when the target java version is greater than the image's jre version`() {
         val project = ProjectBuilder.builder().build()
-        project.applyPlugin {
+        project.applyKtorPlugin {
             getExtension<DockerExtension>().jreVersion.set(JavaVersion.VERSION_11)
         }
         project.extensions.configure(JavaPluginExtension::class.java) {
@@ -44,7 +44,7 @@ class DockerTest {
     fun `name of the source image considers set image's jre version`() {
         val project = ProjectBuilder.builder().build()
 
-        project.applyPlugin {
+        project.applyKtorPlugin {
             getExtension<DockerExtension>().jreVersion.set(JavaVersion.VERSION_17)
         }
 
@@ -59,7 +59,7 @@ class DockerTest {
     @Test
     fun `name of the target image has a default value`() {
         val project = ProjectBuilder.builder().build()
-        project.applyPlugin()
+        project.applyKtorPlugin()
 
         val task = project.tasks.named("setupJibLocal", ConfigureJibLocalTask::class.java).get()
         task.execute()
@@ -69,7 +69,7 @@ class DockerTest {
     @Test
     fun `name of the target image is determined by the docker extension`() {
         val project = ProjectBuilder.builder().build()
-        project.applyPlugin {
+        project.applyKtorPlugin {
             getExtension<DockerExtension>().localImageName.set("target-image")
         }
 
@@ -82,7 +82,7 @@ class DockerTest {
     @Test
     fun `docker extension configures target image name and registry auth`() {
         val project = ProjectBuilder.builder().build()
-        project.applyPlugin {
+        project.applyKtorPlugin {
             getExtension<DockerExtension>().apply {
                 externalRegistry.set(
                     externalRegistry(
@@ -107,7 +107,7 @@ class DockerTest {
     @Test
     fun `docker extension configures tag of the target image`() {
         val project = ProjectBuilder.builder().build()
-        project.applyPlugin {
+        project.applyKtorPlugin {
             getExtension<DockerExtension>().imageTag.set("1.2.3")
         }
 
@@ -120,7 +120,7 @@ class DockerTest {
     @Test
     fun `docker extension adds a tag to the target image tags`() {
         val project = ProjectBuilder.builder().build()
-        project.applyPlugin {
+        project.applyKtorPlugin {
             getExtension<DockerExtension>().imageTag.set("1.2.3")
         }
 
@@ -138,7 +138,7 @@ class DockerTest {
     fun `jib tasks are marked as not compatible with configuration cache`() {
         mockkStatic(GradleVersion::class) {
             val project = ProjectBuilder.builder().build()
-            project.applyPlugin()
+            project.applyKtorPlugin()
 
             val jibTask = project.tasks.named("jib", DefaultTask::class.java).get()
             assertFalse { jibTask.isCompatibleWithConfigurationCache }

--- a/plugin/src/test/kotlin/io/ktor/plugin/DockerTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/DockerTest.kt
@@ -9,16 +9,16 @@ import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.internal.provider.Providers
 import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.util.GradleVersion
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.test.*
 
 class DockerTest {
+    private val project = createProject()
+
     @Test
     fun `cannot build an image when the target java version is greater than the image's jre version`() {
-        val project = ProjectBuilder.builder().build()
         project.applyKtorPlugin {
             getExtension<DockerExtension>().jreVersion.set(JavaVersion.VERSION_11)
         }
@@ -42,8 +42,6 @@ class DockerTest {
 
     @Test
     fun `name of the source image considers set image's jre version`() {
-        val project = ProjectBuilder.builder().build()
-
         project.applyKtorPlugin {
             getExtension<DockerExtension>().jreVersion.set(JavaVersion.VERSION_17)
         }
@@ -58,7 +56,6 @@ class DockerTest {
 
     @Test
     fun `name of the target image has a default value`() {
-        val project = ProjectBuilder.builder().build()
         project.applyKtorPlugin()
 
         val task = project.tasks.named("setupJibLocal", ConfigureJibLocalTask::class.java).get()
@@ -68,7 +65,6 @@ class DockerTest {
     }
     @Test
     fun `name of the target image is determined by the docker extension`() {
-        val project = ProjectBuilder.builder().build()
         project.applyKtorPlugin {
             getExtension<DockerExtension>().localImageName.set("target-image")
         }
@@ -81,7 +77,6 @@ class DockerTest {
 
     @Test
     fun `docker extension configures target image name and registry auth`() {
-        val project = ProjectBuilder.builder().build()
         project.applyKtorPlugin {
             getExtension<DockerExtension>().apply {
                 externalRegistry.set(
@@ -106,7 +101,6 @@ class DockerTest {
 
     @Test
     fun `docker extension configures tag of the target image`() {
-        val project = ProjectBuilder.builder().build()
         project.applyKtorPlugin {
             getExtension<DockerExtension>().imageTag.set("1.2.3")
         }
@@ -119,7 +113,6 @@ class DockerTest {
 
     @Test
     fun `docker extension adds a tag to the target image tags`() {
-        val project = ProjectBuilder.builder().build()
         project.applyKtorPlugin {
             getExtension<DockerExtension>().imageTag.set("1.2.3")
         }
@@ -137,7 +130,6 @@ class DockerTest {
     @Test
     fun `jib tasks are marked as not compatible with configuration cache`() {
         mockkStatic(GradleVersion::class) {
-            val project = ProjectBuilder.builder().build()
             project.applyKtorPlugin()
 
             val jibTask = project.tasks.named("jib", DefaultTask::class.java).get()
@@ -153,8 +145,8 @@ class DockerTest {
     @MethodSource("dataForTestingTasks")
     fun `has a task that depends on jib tasks`(data: Pair<String, List<String>>) {
         val (taskName, dependentTasks) = data
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        project.applyKtorPlugin()
+
         val task = project.tasks.named(taskName).get()
         assertEquals("Ktor", task.group)
         assertFalse { task.description.isNullOrEmpty() }

--- a/plugin/src/test/kotlin/io/ktor/plugin/FatJarTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/FatJarTest.kt
@@ -2,7 +2,6 @@ package io.ktor.plugin
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.ktor.plugin.features.*
-import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -11,18 +10,18 @@ import kotlin.test.assertNotNull
 class FatJarTest {
     @Test
     fun `output filename is built from the project name by default`() {
-        val project = ProjectBuilder.builder().apply {
-            withName("fat-example")
-        }.build()
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        val project = createProject { withName("fat-example") }
+        project.applyKtorPlugin()
+
         val shadowJarTask = project.tasks.named("shadowJar", ShadowJar::class.java)
         assertEquals("fat-example-all.jar", shadowJarTask.get().archiveFileName.get())
     }
 
     @Test
     fun `output filename is overridden by the extension`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        val project = createProject()
+        project.applyKtorPlugin()
+
         project.extensions.configure(KtorExtension::class.java) {
             it.getExtension<FatJarExtension>().archiveFileName.set("fat.jar")
         }
@@ -32,8 +31,9 @@ class FatJarTest {
 
     @Test
     fun `has buildFatJar task that just depends on shadowJar task`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        val project = createProject()
+        project.applyKtorPlugin()
+
         val buildTask = project.tasks.named("buildFatJar").get()
         val dependencies = buildTask.taskDependencies.getDependencies(buildTask)
         assertEquals(1, dependencies.size)
@@ -42,8 +42,9 @@ class FatJarTest {
 
     @Test
     fun `runShadow task depends on buildFatJar task`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        val project = createProject()
+        project.applyKtorPlugin()
+
         val runTask = project.tasks.named("runShadow").get()
         val dependencies = runTask.taskDependencies.getDependencies(runTask)
         assertNotNull(dependencies.find { it.name == "buildFatJar" }, "runShadow task should depend on buildFatJar")
@@ -51,8 +52,9 @@ class FatJarTest {
 
     @Test
     fun `has runFatJar task that depends on runShadow task`() {
-        val project = ProjectBuilder.builder().build()
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        val project = createProject()
+        project.applyKtorPlugin()
+
         val runTask = project.tasks.named("runFatJar").get()
         assertEquals("Ktor", runTask.group)
         assertFalse { runTask.description.isNullOrEmpty() }

--- a/plugin/src/test/kotlin/io/ktor/plugin/GradleVersionCompatibilityTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/GradleVersionCompatibilityTest.kt
@@ -1,24 +1,12 @@
 package io.ktor.plugin
 
-import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
-import java.io.File
 
-class GradleVersionCompatibilityTest {
+class GradleVersionCompatibilityTest : IntegrationTest() {
     @ParameterizedTest
     @ValueSource(strings = ["8.3", "8.14"])
-    fun testProjectBuild(gradleVersion: String, @TempDir projectDir: File) {
-        projectDir.resolve("build.gradle.kts").writeText(
-            """
-            plugins {
-                kotlin("jvm") version "2.1.20"
-                id("io.ktor.plugin")
-            }
-            """.trimIndent()
-        )
-        createGradleRunner(projectDir)
-            .withGradleVersion(gradleVersion)
-            .build()
+    fun testProjectBuild(gradleVersion: String) {
+        runBuild { withGradleVersion(gradleVersion) }
     }
 }

--- a/plugin/src/test/kotlin/io/ktor/plugin/GradleVersionCompatibilityTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/GradleVersionCompatibilityTest.kt
@@ -7,9 +7,16 @@ import java.io.File
 
 class GradleVersionCompatibilityTest {
     @ParameterizedTest
-    @ValueSource(strings = ["8.3", "8.10.2"])
+    @ValueSource(strings = ["8.3", "8.14"])
     fun testProjectBuild(gradleVersion: String, @TempDir projectDir: File) {
-        projectDir.resolve("build.gradle.kts").writeText("""plugins { id("io.ktor.plugin") }""")
+        projectDir.resolve("build.gradle.kts").writeText(
+            """
+            plugins {
+                kotlin("jvm") version "2.1.20"
+                id("io.ktor.plugin")
+            }
+            """.trimIndent()
+        )
         createGradleRunner(projectDir)
             .withGradleVersion(gradleVersion)
             .build()

--- a/plugin/src/test/kotlin/io/ktor/plugin/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/IntegrationTest.kt
@@ -1,0 +1,53 @@
+package io.ktor.plugin
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.BeforeTest
+
+abstract class IntegrationTest {
+
+    @field:TempDir
+    protected lateinit var projectDir: File
+
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+    protected val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+
+    @BeforeTest
+    open fun setup() {
+        settingsFile.writeCode(
+            """
+            pluginManagement {
+                repositories {
+                    mavenLocal {
+                        content { includeGroup("io.ktor.plugin") }
+                    }
+                    gradlePluginPortal()
+                }
+            }
+
+            rootProject.name = "test"
+            """
+        )
+        buildFile.writeCode(APPLY_KOTLIN_JVM_AND_KTOR)
+    }
+
+    private val runner by lazy {
+        createGradleRunner(projectDir)
+            .forwardOutput()
+    }
+
+    protected fun runBuild(vararg args: String, configure: GradleRunner.() -> Unit = {}): BuildResult {
+        return runner.apply(configure).withArguments(args.asList() + "--stacktrace").build()
+    }
+
+    companion object {
+        const val APPLY_KOTLIN_JVM_AND_KTOR = """
+            plugins {
+                kotlin("jvm") version "$KOTLIN_VERSION"
+                id("io.ktor.plugin") version "$KTOR_VERSION"
+            }
+        """
+    }
+}

--- a/plugin/src/test/kotlin/io/ktor/plugin/IntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/IntegrationTest.kt
@@ -16,7 +16,7 @@ abstract class IntegrationTest {
 
     @BeforeTest
     open fun setup() {
-        settingsFile.writeCode(
+        settingsFile.writeGradle(
             """
             pluginManagement {
                 repositories {
@@ -30,7 +30,7 @@ abstract class IntegrationTest {
             rootProject.name = "test"
             """
         )
-        buildFile.writeCode(APPLY_KOTLIN_JVM_AND_KTOR)
+        buildFile.writeGradle(APPLY_KOTLIN_JVM_AND_KTOR)
     }
 
     private val runner by lazy {
@@ -40,6 +40,12 @@ abstract class IntegrationTest {
 
     protected fun runBuild(vararg args: String, configure: GradleRunner.() -> Unit = {}): BuildResult {
         return runner.apply(configure).withArguments(args.asList() + "--stacktrace").build()
+    }
+
+    protected fun file(path: String): File {
+        return projectDir.resolve(path).apply {
+            parentFile.mkdirs()
+        }
     }
 
     companion object {

--- a/plugin/src/test/kotlin/io/ktor/plugin/KotlinPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/KotlinPluginIntegrationTest.kt
@@ -1,0 +1,142 @@
+package io.ktor.plugin
+
+import org.gradle.testkit.runner.BuildResult
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import kotlin.test.assertContains
+
+class KotlinPluginIntegrationTest : IntegrationTest() {
+
+    @Test
+    fun `applied after kotlin-jvm plugin`() {
+        buildFile.writeGradle(
+            APPLY_KOTLIN_JVM_AND_KTOR,
+            PRINT_KTOR_TASKS,
+        )
+
+        runBuild().assertKtorTasksAdded(allTasks)
+    }
+
+    @Test
+    fun `applied before kotlin-jvm plugin`() {
+        buildFile.writeGradle(
+            """
+            plugins {
+                id("io.ktor.plugin") version "$KTOR_VERSION"
+                kotlin("jvm") version "$KOTLIN_VERSION"
+            }
+            """,
+            PRINT_KTOR_TASKS,
+        )
+
+        runBuild().assertKtorTasksAdded(allTasks)
+    }
+
+    @Test
+    fun `applied with kotlin-multiplatform plugin before 2-1-20`() {
+        buildFile.writeGradle(
+            """
+            plugins {
+                kotlin("multiplatform") version "2.1.0"
+                id("io.ktor.plugin") version "$KTOR_VERSION"
+            }
+
+            kotlin {
+                jvm()
+            }
+            """,
+            PRINT_KTOR_TASKS,
+        )
+
+        runBuild().assertKtorTasksAdded(fatJarTasks)
+    }
+
+    @Test
+    fun `applied with kotlin-multiplatform plugin after 2-1-20`() {
+        buildFile.writeGradle(
+            """
+            plugins {
+                kotlin("multiplatform") version "$KOTLIN_VERSION"
+                id("io.ktor.plugin") version "$KTOR_VERSION"
+            }
+
+            kotlin {
+                jvm()
+            }
+            """,
+            PRINT_KTOR_TASKS,
+        )
+
+        runBuild().assertKtorTasksAdded(emptySet())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "true,  [-Dio.ktor.development=true]",
+        "false, []",
+    )
+    fun `applied with kotlin-multiplatform plugin with executions and development mode configured`(
+        development: Boolean,
+        expectedArgs: String
+    ) {
+        file("src/jvmMain/kotlin/Main.kt").writeKotlin(
+            """
+            fun main() {
+                println("Hello, world!")
+            }
+            """
+        )
+
+        buildFile.writeGradle(
+            """
+            import org.gradle.api.tasks.JavaExec
+
+            plugins {
+                kotlin("multiplatform") version "$KOTLIN_VERSION"
+                id("io.ktor.plugin") version "$KTOR_VERSION"
+            }
+
+            kotlin {
+                jvm {
+                    binaries {
+                        executable {
+                            mainClass = "MainKt"
+                        }
+                    }
+                }
+            }
+            
+            ktor {
+                development = $development
+            }
+
+            afterEvaluate {
+                val runJvm = tasks.named<JavaExec>("runJvm").get()
+                println("JVM args: " + runJvm.jvmArguments.get())
+            }
+            """,
+        )
+
+        val result = runBuild()
+        assertContains(result.output.lines(), "JVM args: $expectedArgs")
+    }
+
+    private companion object {
+        const val PRINT_KTOR_TASKS = """
+            afterEvaluate {
+               val tasks = tasks.filter { it.group == "Ktor" }
+               println("Ktor tasks: " + tasks.map { it.name }.sorted())
+            }
+        """
+
+        val fatJarTasks = setOf("buildFatJar", "runFatJar")
+        val jibTasks = setOf("buildImage", "publishImage", "publishImageToLocalRegistry", "runDocker")
+        val allTasks = fatJarTasks + jibTasks
+
+        /** Should be used together with [PRINT_KTOR_TASKS]. */
+        fun BuildResult.assertKtorTasksAdded(tasks: Set<String>) {
+            assertContains(output.lines(), "Ktor tasks: " + tasks.sorted())
+        }
+    }
+}

--- a/plugin/src/test/kotlin/io/ktor/plugin/KotlinPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/KotlinPluginIntegrationTest.kt
@@ -21,7 +21,7 @@ class KotlinPluginIntegrationTest : IntegrationTest() {
 
         val result = runBuild()
         result.assertNoKtorTasksAdded()
-        assertContains(result.output, "warning: Ktor Gradle plugin cannot be used without Kotlin Gradle plugin.")
+        assertContains(result.output, "warning: The Ktor Gradle plugin requires the Kotlin Gradle plugin.")
     }
 
     @Test
@@ -86,7 +86,7 @@ class KotlinPluginIntegrationTest : IntegrationTest() {
 
         val result = runBuild()
         result.assertNoKtorTasksAdded()
-        assertContains(result.output, "warning: Ktor Gradle plugin is not fully compatible with Kotlin Multiplatform plugin.")
+        assertContains(result.output, "warning: The Ktor Gradle plugin is not fully compatible with the Kotlin Multiplatform plugin.")
     }
 
     @ParameterizedTest

--- a/plugin/src/test/kotlin/io/ktor/plugin/PluginTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/PluginTest.kt
@@ -2,16 +2,15 @@ package io.ktor.plugin
 
 import io.ktor.plugin.internal.*
 import org.gradle.api.plugins.ApplicationPlugin
-import org.gradle.testfixtures.ProjectBuilder
 import kotlin.test.*
 
 class PluginTest {
 
-    private val project = ProjectBuilder.builder().build()
+    private val project = createProject()
 
     @BeforeTest
     fun setup() {
-        project.plugins.apply(KtorGradlePlugin::class.java)
+        project.applyKtorPlugin()
     }
 
     @Test
@@ -87,8 +86,10 @@ class PluginTest {
 
     @Test
     fun `plugin does not add any dependencies except the bom file`() {
-        val deps = project.configurations.flatMap { it.dependencies }
-        assertEquals(1, deps.size)
+        val deps = project.configurations
+            .filter { it.name != "kotlinBuildToolsApiClasspath" }
+            .flatMap { it.dependencies }
+        assertEquals(1, deps.size, "Expected only the Ktor BOM dependency, but got: $deps")
         val bom = deps.single()
         assertEquals("io.ktor", bom.group)
         assertEquals("ktor-bom", bom.name)

--- a/plugin/src/test/kotlin/io/ktor/plugin/TestConstants.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/TestConstants.kt
@@ -1,0 +1,3 @@
+package io.ktor.plugin
+
+internal const val KOTLIN_VERSION = "2.1.20"

--- a/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
@@ -1,13 +1,17 @@
 package io.ktor.plugin
 
 import io.ktor.plugin.features.*
+import io.ktor.plugin.internal.*
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.GradleRunner
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import java.io.File
 
-internal fun Project.applyPlugin(configureExt: KtorExtension.() -> Unit = {}) {
-    project.plugins.apply(KtorGradlePlugin::class.java)
+internal fun Project.applyKtorPlugin(configureExt: KtorExtension.() -> Unit = {}) {
+    project.plugins.apply<KotlinPluginWrapper>()
+    project.plugins.apply<KtorGradlePlugin>()
     project.extensions.configure(KtorExtension::class.java) { ext ->
         ext.configureExt()
     }
@@ -18,4 +22,7 @@ internal fun Project.evaluate() {
 }
 
 internal fun createGradleRunner(projectDir: File): GradleRunner =
-    GradleRunner.create().withProjectDir(projectDir).withPluginClasspath()
+    GradleRunner.create().withProjectDir(projectDir).withPluginClasspath().withArguments("--stacktrace")
+
+internal fun createProject(configure: ProjectBuilder.() -> Unit = {}): Project =
+    ProjectBuilder.builder().apply(configure).build()

--- a/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
@@ -10,8 +10,8 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import java.io.File
 
 internal fun Project.applyKtorPlugin(configureExt: KtorExtension.() -> Unit = {}) {
-    project.plugins.apply<KotlinPluginWrapper>()
-    project.plugins.apply<KtorGradlePlugin>()
+    apply<KotlinPluginWrapper>()
+    apply<KtorGradlePlugin>()
     project.extensions.configure(KtorExtension::class.java) { ext ->
         ext.configureExt()
     }

--- a/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
@@ -22,7 +22,11 @@ internal fun Project.evaluate() {
 }
 
 internal fun createGradleRunner(projectDir: File): GradleRunner =
-    GradleRunner.create().withProjectDir(projectDir).withPluginClasspath().withArguments("--stacktrace")
+    GradleRunner.create().withProjectDir(projectDir).withArguments("--stacktrace")
 
 internal fun createProject(configure: ProjectBuilder.() -> Unit = {}): Project =
     ProjectBuilder.builder().apply(configure).build()
+
+internal fun File.writeCode(vararg codeBlocks: String) {
+    writeText(codeBlocks.joinToString("\n\n") { it.trimIndent() })
+}

--- a/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/TestUtils.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.GradleRunner
+import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import java.io.File
 
@@ -27,6 +28,12 @@ internal fun createGradleRunner(projectDir: File): GradleRunner =
 internal fun createProject(configure: ProjectBuilder.() -> Unit = {}): Project =
     ProjectBuilder.builder().apply(configure).build()
 
-internal fun File.writeCode(vararg codeBlocks: String) {
+internal fun File.writeKotlin(@Language("kt") code: String) = writeCodeBlocks(code)
+
+// .gradle.kts language injection is not supported, but maybe some day it will be
+// https://youtrack.jetbrains.com/issue/KTIJ-23863/Support-Language-injection-for-Gradle-Kotlin-DSL-kts-scripts
+internal fun File.writeGradle(@Language("gradle.kts") vararg codeBlocks: String) = writeCodeBlocks(*codeBlocks)
+
+internal fun File.writeCodeBlocks(vararg codeBlocks: String) {
     writeText(codeBlocks.joinToString("\n\n") { it.trimIndent() })
 }


### PR DESCRIPTION
**Motivation:**
[KTOR-8444](https://youtrack.jetbrains.com/issue/KTOR-8444) Basic compatibility with the KMP plugin
[KTOR-8419](https://youtrack.jetbrains.com/issue/KTOR-8419) The plugin applies 'application' plugin, which is incompatible with KMP 2.1.20

**Solution:**
- Changed the way how we apply third-party plugins (application, shadow, JIB). Now these plugins are applied only for projects with `kotlin-jvm`
- Added propagation of `ktor.development` to the tasks created with [KMP's replacement of Application plugin﻿](https://kotlinlang.org/docs/whatsnew2120.html#kotlin-multiplatform-new-dsl-to-replace-gradle-s-application-plugin)
- Fixed the adding of `ktor-bom` dependency in KMP projects
- Added some integration tests checking compatibility with Kotlin JVM and Kotlin Multiplatform plugins