### PR TITLE
KTOR-8678 Enforce Commons Lang v3.18.0+

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -27,6 +27,13 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlin.test.junit5)
     testImplementation(libs.junit.jupiter.params)
+
+    constraints {
+        // TODO: Check if this constraint is still needed after each JIB update
+        implementation("org.apache.commons:commons-lang3:[3.18.0,)") {
+            because("Versions 3.0..<3.18.0 are affected by CVE-2025-48924")
+        }
+    }
 }
 
 kotlin {


### PR DESCRIPTION
Fixes [KTOR-8678](https://youtrack.jetbrains.com/issue/KTOR-8678) Moderate vulnerability in Apache Commons Lang v3.14.0