### PR TITLE
Configure publishing

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(libs.gradlePlugin.mavenPublishing)
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,18 @@
+@file:Suppress("UnstableApiUsage")
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"

--- a/build-logic/src/main/kotlin/Version.kt
+++ b/build-logic/src/main/kotlin/Version.kt
@@ -1,0 +1,13 @@
+import org.gradle.api.Project
+
+private val EapBranchRegex = Regex("^.*/(.*)-eap$")
+
+fun Project.resolveVersion(ktorVersion: String): String {
+    return listOfNotNull(
+        ktorVersion,
+        System.getenv("GIT_BRANCH")
+            ?.let(EapBranchRegex::matchEntire)
+            ?.groupValues?.get(1),
+        findProperty("versionSuffix")
+    ).joinToString("-")
+}

--- a/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
+++ b/build-logic/src/main/kotlin/ktorbuild.publish.gradle.kts
@@ -1,0 +1,73 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+
+plugins {
+    id("com.vanniktech.maven.publish")
+}
+
+mavenPublishing {
+    if (shouldPublishToMavenCentral()) publishToMavenCentral(automaticRelease = true)
+    configureSigning(this)
+
+    pom {
+        name = project.name
+        description = checkNotNull(project.description) { "Project description missing" }
+        url = "https://github.com/ktorio/ktor-build-plugins"
+        licenses {
+            license {
+                name = "The Apache Software License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "repo"
+            }
+        }
+        developers {
+            developer {
+                id = "JetBrains"
+                name = "Jetbrains Team"
+                organization = "JetBrains"
+                organizationUrl = "https://www.jetbrains.com"
+            }
+        }
+        scm {
+            url = "https://github.com/ktorio/ktor-build-plugins.git"
+        }
+    }
+}
+
+publishing {
+    repositories {
+        maybeSpace()
+        mavenLocal()
+    }
+}
+
+private fun shouldPublishToMavenCentral(): Boolean =
+    providers.gradleProperty("mavenCentralUsername").isPresent &&
+            providers.gradleProperty("mavenCentralPassword").isPresent
+
+private fun RepositoryHandler.maybeSpace() {
+    if (hasProperty("space")) {
+        val publishingUrl = System.getenv("PUBLISHING_URL")
+        val publishingUser = System.getenv("PUBLISHING_USER")
+        val publishingPassword = System.getenv("PUBLISHING_PASSWORD")
+        if (publishingUrl == null || publishingUser == null || publishingPassword == null) {
+            throw GradleException("Missing publishing credentials (PUBLISHING_URL / PUBLISHING_USER / PUBLISHING_PASSWORD)")
+        }
+
+        maven(url = publishingUrl) {
+            name = "space"
+            credentials {
+                username = publishingUser
+                password = publishingPassword
+            }
+        }
+    }
+}
+
+private fun Project.configureSigning(mavenPublishing: MavenPublishBaseExtension) {
+    extra["signing.gnupg.keyName"] = (System.getenv("SIGN_KEY_ID") ?: return)
+    extra["signing.gnupg.passphrase"] = (System.getenv("SIGN_KEY_PASSPHRASE") ?: return)
+
+    pluginManager.apply("signing")
+    mavenPublishing.signAllPublications()
+    the<SigningExtension>().useGpgCmd()
+}

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -12,11 +12,8 @@ plugins {
 val artifact = "ktor-compiler-plugin"
 
 group = "io.ktor"
-version = listOfNotNull(
-    libs.plugins.ktor.get().version,
-    System.getenv("GIT_BRANCH")?.let(Regex("^.*/(.*)-eap$")::matchEntire)?.groupValues?.get(1)?.takeIf { it != "main" },
-    findProperty("versionSuffix")
-).joinToString("-")
+version = resolveVersion(libs.versions.ktor.plugin.get())
+description = "Ktor Compiler Plugin"
 
 val testSamples by configurations.creating
 val testData by sourceSets.creating {

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -1,12 +1,10 @@
-import org.gradle.kotlin.dsl.provideDelegate
-
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.buildconfig)
     alias(libs.plugins.kotlinx.serialization)
-    `maven-publish`
     `java-test-fixtures`
     idea
+    id("ktorbuild.publish")
 }
 
 val artifact = "ktor-compiler-plugin"
@@ -137,32 +135,6 @@ tasks {
 
     compileTestKotlin {
         dependsOn(generateTests)
-    }
-}
-
-publishing {
-    if (hasProperty("space")) {
-        val publishingUrl = System.getenv("PUBLISHING_URL")
-        val publishingUser = System.getenv("PUBLISHING_USER")
-        val publishingPassword = System.getenv("PUBLISHING_PASSWORD")
-        if (publishingUrl == null || publishingUser == null || publishingPassword == null) {
-            throw GradleException("Missing publishing credentials (PUBLISHING_URL / PUBLISHING_USER / PUBLISHING_PASSWORD)")
-        }
-        repositories {
-            maven(url = publishingUrl) {
-                name = "space"
-                credentials {
-                    username = publishingUser
-                    password = publishingPassword
-                }
-            }
-        }
-    }
-    publications {
-        create<MavenPublication>("maven") {
-            artifactId = artifact
-            from(components["java"])
-        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ pluginPublish = "1.3.1"
 gradlePlugin-shadow = "8.3.9"
 gradlePlugin-jib = "3.4.5"
 gradlePlugin-graalvm = "0.10.6"
+gradlePlugin-mavenPublishing = "0.34.0"
 binaryCompatibilityValidator = "0.18.1"
 junit = "5.13.4"
 mockk = "1.14.5"
@@ -17,6 +18,7 @@ gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 gradlePlugin-shadow = { module = "com.gradleup.shadow:shadow-gradle-plugin", version.ref = "gradlePlugin-shadow" }
 gradlePlugin-jib = { module = "com.google.cloud.tools:jib-gradle-plugin", version.ref = "gradlePlugin-jib" }
 gradlePlugin-graalvm = { module = "org.graalvm.buildtools:native-gradle-plugin", version.ref = "gradlePlugin-graalvm" }
+gradlePlugin-mavenPublishing = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradlePlugin-mavenPublishing" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,12 +1,13 @@
+
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.gradle.kotlin.dsl.maven
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.pluginPublish)
     alias(libs.plugins.binaryCompatibilityValidator)
     alias(libs.plugins.buildconfig)
+    id("ktorbuild.publish")
 }
 
 group = libs.plugins.ktor.get().pluginId
@@ -101,23 +102,4 @@ tasks.withType<Test>().configureEach {
     // The plugin should be published to MavenLocal to be available in integration tests
     // We can't use GradleRunner.withPluginClasspath() because of https://github.com/gradle/gradle/issues/22466
     dependsOn(publishToMavenLocal)
-}
-
-if (hasProperty("space")) {
-    val publishingUrl = System.getenv("PUBLISHING_URL")
-    val publishingUser = System.getenv("PUBLISHING_USER")
-    if (publishingUrl == null || publishingUser == null) {
-        throw GradleException("Missing publishing credentials")
-    }
-    publishing {
-        repositories {
-            maven(url = publishingUrl) {
-                name = "space"
-                credentials {
-                    username = publishingUser
-                    password = System.getenv("PUBLISHING_PASSWORD")
-                }
-            }
-        }
-    }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -10,11 +10,8 @@ plugins {
 }
 
 group = libs.plugins.ktor.get().pluginId
-version = listOfNotNull(
-    libs.plugins.ktor.get().version,
-    System.getenv("GIT_BRANCH")?.let(Regex("^.*/(.*)-eap$")::matchEntire)?.groupValues?.get(1)?.takeIf { it != "main" },
-    findProperty("versionSuffix")
-).joinToString("-")
+version = resolveVersion(libs.versions.ktor.plugin.get())
+description = "Ktor Gradle plugin"
 
 dependencies {
     implementation(gradleApi())

--- a/plugin/src/main/kotlin/io/ktor/plugin/features/OpenAPI.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/OpenAPI.kt
@@ -4,7 +4,6 @@ import io.ktor.plugin.*
 import io.ktor.plugin.KtorGradlePlugin.Companion.COMPILER_PLUGIN_ID
 import io.ktor.plugin.KtorGradlePlugin.Companion.VERSION
 import io.ktor.plugin.internal.*
-import io.ktor.plugin.ktorOutputDir
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Property

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,8 @@ dependencyResolutionManagement {
     }
 }
 
+includeBuild("build-logic")
+
 include("compiler-plugin")
 include("samples:ktor-fatjar-sample")
 include("samples:ktor-docker-sample")


### PR DESCRIPTION
Configure publishing via `build-logic` module similar to how it is done in the Ktor repository.