### PR TITLE
KTOR-9422 Support delegate property access inference

### DIFF
--- a/ktor-compiler-plugin/src/io/ktor/openapi/ir/inference/ParameterInference.kt
+++ b/ktor-compiler-plugin/src/io/ktor/openapi/ir/inference/ParameterInference.kt
@@ -2,36 +2,72 @@ package io.ktor.openapi.ir.inference
 
 import io.ktor.openapi.ir.*
 import io.ktor.openapi.routing.*
+import io.ktor.openapi.routing.TypeReference.Companion.asReference
 import org.jetbrains.kotlin.ir.declarations.IrParameterKind
 import org.jetbrains.kotlin.ir.expressions.IrCall
+import org.jetbrains.kotlin.ir.expressions.IrLocalDelegatedPropertyReference
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.isString
 
 val ParameterInference = IrCallHandlerInference { call: IrCall ->
-    if (!call.symbol.owner.name.asString().startsWith("get")) return@IrCallHandlerInference null
-    val receiver = call.functionReceiver ?: return@IrCallHandlerInference null
-    if (receiver.type.classFqName?.asString() != "io.ktor.util.StringValues") return@IrCallHandlerInference null
-    val getParameter = call.symbol.owner.parameters.firstOrNull {
-        it.kind == IrParameterKind.Regular && it.type.isString()
-    } ?: return@IrCallHandlerInference null
+    val functionName = call.symbol.owner.name.asString()
 
-    val key = call.arguments[getParameter.indexInParameters]
-        ?.let { LocalReference.of(it) }
-        ?: return@IrCallHandlerInference null
+    when (functionName) {
+        // StringValues lookup
+        "get", "getAll", "getOrFail" -> {
+            val keyArg = call.symbol.owner.parameters.firstOrNull {
+                it.kind == IrParameterKind.Regular && it.type.isString()
+            } ?: return@IrCallHandlerInference null
+            val parameterName = call.arguments[keyArg.indexInParameters]
+                ?.let { LocalReference.of(it) }
+                ?: return@IrCallHandlerInference null
+            inferFromStringValuesAccess(
+                call = call,
+                parameterName = parameterName,
+                parameterType = null
+            )
+        }
+        // Delegate property access
+        "getValue" -> {
+            val receiver = call.functionReceiver ?: return@IrCallHandlerInference null
+            if (receiver.type.classFqName?.asString() != "io.ktor.http.Parameters")
+                return@IrCallHandlerInference null
+            val propertyReference = call.arguments.filterIsInstance<IrLocalDelegatedPropertyReference>().firstOrNull()
+                ?: return@IrCallHandlerInference null
+            val propertyName = propertyReference.symbol.owner.name.asString()
+            inferFromStringValuesAccess(
+                call = call,
+                parameterName = LocalReference.of(propertyName),
+                parameterType = call.type.asReference()
+            )
+        }
 
-    val receiverArgCall = call.arguments[receiver.indexInParameters] as? IrCall
-
-    // we can sometimes infer what kind of parameter it is from the receiver
-    // this is not the case for the usual `call.parameters` reference,
-    // or when we're not using a property getter
-    when(receiverArgCall?.symbol?.owner?.name?.asString()) {
-        "<get-headers>" -> listOf(RouteField.Parameter(ParamIn.HEADER, key))
-        "<get-pathVariables>",
-        "<get-pathParameters>" -> listOf(RouteField.Parameter(ParamIn.PATH, key))
-        "<get-queryParameters>" -> listOf(RouteField.Parameter(ParamIn.QUERY, key))
-
-        // ambiguous scenario, we avoid defining `in` for now
-        // this can usually be inferred later at runtime
-        else -> listOf(RouteField.Parameter(name = key))
+        else -> null
     }
+}
+
+private fun inferFromStringValuesAccess(
+    call: IrCall,
+    parameterName: LocalReference,
+    parameterType: TypeReference?,
+): List<RouteField>? {
+    val receiver = call.functionReceiver ?: return null
+    val receiverTypeName = receiver.type.classFqName?.asString()
+    if (receiverTypeName !in listOf("io.ktor.util.StringValues", "io.ktor.http.Parameters")) return null
+
+    val receiverCall = call.arguments[receiver.indexInParameters] as? IrCall
+    val inValue = when (receiverCall?.symbol?.owner?.name?.asString()) {
+        "<get-headers>" -> ParamIn.HEADER
+        "<get-pathVariables>",
+        "<get-pathParameters>" -> ParamIn.PATH
+        "<get-queryParameters>" -> ParamIn.QUERY
+        else -> null
+    }
+    return listOf(
+        RouteField.Parameter(
+            `in` = inValue,
+            name = parameterName,
+            typeReference = parameterType
+        )
+    )
 }

--- a/ktor-compiler-plugin/testData/openapi/Parameters.expected.json
+++ b/ktor-compiler-plugin/testData/openapi/Parameters.expected.json
@@ -52,14 +52,66 @@
                     },
                     {
                         "name": "f",
-                        "in": "header",
+                        "in": "query",
                         "schema": {
                             "type": "string"
                         }
                     },
                     {
                         "name": "g",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "h",
                         "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "i",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "content": {
+                            "text/plain": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/parameters/delegates/{a}/{b}": {
+            "get": {
+                "summary": "",
+                "parameters": [
+                    {
+                        "name": "a",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "b",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "c",
+                        "in": "query",
                         "schema": {
                             "type": "string"
                         }

--- a/ktor-compiler-plugin/testData/openapi/Parameters.kt
+++ b/ktor-compiler-plugin/testData/openapi/Parameters.kt
@@ -6,6 +6,8 @@ import io.ktor.server.application.Application
 import io.ktor.server.request.header
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.ktor.server.util.getOrFail
+import io.ktor.server.util.getValue
 
 fun Application.installParameters() {
     routing {
@@ -19,10 +21,20 @@ fun Application.installParameters() {
                 call.request.pathVariables["c"],
                 call.queryParameters["d"],
                 call.request.queryParameters["e"],
-                call.request.headers["f"],
-                call.request.headers.getAll("g"),
-                call.request.header("h")
+                call.request.queryParameters.getAll("f"),
+                call.request.queryParameters.getOrFail("g"),
+                call.request.headers["h"],
+                call.request.headers.getAll("i"),
+                call.request.header("j")
             ).joinToString())
+        }
+
+        get("/parameters/delegates/{a}/{b}") {
+            val a: String by call.parameters
+            val b: Int by call.pathParameters
+            val c: String by call.queryParameters
+
+            call.respondText(listOf(a, b, c).joinToString())
         }
     }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/KTOR-9422/OpenAPI-code-inference-misses-property-delegation

In my defense, I only missed this because I didn't know the feature existed.  Now, it'll handle query or path parameters when using property delegation, inferring the parameters from the property names, and schema from the declared types.