### PR TITLE
KTOR-9602 Add support for Docker environment variables in Jib configuration

### DIFF
--- a/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/Docker.kt
@@ -235,6 +235,14 @@ internal abstract class ConfigureJibTaskBase(@get:Input val isExternal: Boolean)
         val tag: String = dockerExtension.imageTag.get()
         jibExtension.to.tags = jibExtension.to.tags + tag
 
+        val envVars = dockerExtension.environmentVariables.get()
+            .filter { it.value != null }
+            .associate { it.variable to it.value!! }
+        if (envVars.isNotEmpty()) {
+            jibExtension.container.environment =
+                (jibExtension.container.environment ?: emptyMap()) + envVars
+        }
+
         val projectJava = project.javaVersion
         val imageJava = dockerExtension.jreVersion.get()
         if (imageJava < projectJava) {

--- a/plugin/src/test/kotlin/io/ktor/plugin/DockerTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/DockerTest.kt
@@ -157,6 +157,55 @@ class DockerTest {
         assertTrue { dependencies.contains(project.tasks.named(dependentTasks[1]).get()) }
     }
 
+    @Test
+    fun `environment variables should be included in the image configuration`() {
+        project.applyKtorPlugin {
+            getExtension<DockerExtension>().environmentVariable("NAME", "Container")
+        }
+
+        val task = project.tasks.named("setupJibLocal", ConfigureJibLocalTask::class.java).get()
+        task.execute()
+
+        val jibExtension = project.extensions.getByType(JibExtension::class.java)
+        assertEquals(mapOf("NAME" to "Container"), jibExtension.container.environment)
+    }
+
+    @Test
+    fun `docker extension does not include environment variables without values in the image`() {
+        project.applyKtorPlugin {
+            getExtension<DockerExtension>().apply {
+                environmentVariables.add(DockerEnvironmentVariable("HOST_VAR")) // null value
+                environmentVariable("APP_ENV", "production")
+            }
+        }
+
+        val task = project.tasks.named("setupJibLocal", ConfigureJibLocalTask::class.java).get()
+        task.execute()
+
+        val jibExtension = project.extensions.getByType(JibExtension::class.java)
+        assertEquals(mapOf("APP_ENV" to "production"), jibExtension.container.environment)
+    }
+
+    @Test
+    fun `docker extension merges environment variables with existing jib container config`() {
+        project.applyKtorPlugin {
+            getExtension<DockerExtension>().environmentVariable("NAME", "Container")
+        }
+
+        project.extensions.configure(JibExtension::class.java) { ext ->
+            ext.container.environment = mapOf("EXISTING_VAR" to "existing_value")
+        }
+
+        val task = project.tasks.named("setupJibLocal", ConfigureJibLocalTask::class.java).get()
+        task.execute()
+
+        val jibExtension = project.extensions.getByType(JibExtension::class.java)
+        assertEquals(
+            mapOf("EXISTING_VAR" to "existing_value", "NAME" to "Container"),
+            jibExtension.container.environment
+        )
+    }
+
     companion object {
         @JvmStatic
         fun dataForTestingTasks() = listOf (


### PR DESCRIPTION
This PR resolves KTOR-9602 by ensuring that environment variables configured via the `DockerExtension` are properly passed down and merged into the `JibExtension` container configuration.

## Changes
- Updated `ConfigureJibTaskBase` in `Docker.kt` to extract environment variables from `dockerExtension`.
- Added filtering to exclude environment variables without explicit values (`null` value placeholders which are intended for host inheritance but are invalid in the image configuration context).
- Merged these environment variables with any pre-existing environment configurations in `jibExtension.container`.

## Testing
Added 3 unit tests in `DockerTest.kt`:
1. `environment variables should be included in the image configuration` - Verifies that valid variables are correctly propagated.
2. `docker extension does not include environment variables without values in the image` - Verifies that `null` values are safely ignored and filtered out.
3. `docker extension merges environment variables with existing jib container config` - Verifies that new variables do not overwrite pre-existing Jib configurations but merge with them instead.