### PR TITLE
Prevent enabling compiler plugin for Kotlin versions < 2.4.0

### DIFF
--- a/plugin/src/main/kotlin/io/ktor/plugin/features/OpenAPI.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/features/OpenAPI.kt
@@ -1,23 +1,38 @@
 package io.ktor.plugin.features
 
 import io.ktor.plugin.*
+import io.ktor.plugin.internal.KotlinVersion
 import io.ktor.plugin.internal.whenKotlinPluginApplied
 import org.gradle.api.Project
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 internal fun Project.configureOpenApi() {
     val ext = createKtorExtension<OpenApiExtension>("openApi")
 
     whenKotlinPluginApplied {
+        // The Ktor OpenAPI compiler plugin artifact depends on Kotlin compiler internals that are
+        // only available starting from KotlinVersion.V2_4_0; loading it on older Kotlin versions
+        // results in a NoClassDefFoundError at compile time. Skip applying it on incompatible
+        // Kotlin versions instead of failing the build for users who don't even use OpenAPI.
+        if (!isOpenApiCompilerPluginSupported()) return@whenKotlinPluginApplied
         pluginManager.apply(CompilerPlugin::class.java)
     }
 
     afterEvaluate {
         try {
             if (ext.enabled.get()) {
+                if (!isOpenApiCompilerPluginSupported()) {
+                    logger.warn(
+                        "warning: Ktor OpenAPI inference is enabled but requires Kotlin " +
+                            "${KotlinVersion.V2_4_0} or higher (found ${getKotlinPluginVersion()}). " +
+                            "OpenAPI inference will be skipped."
+                    )
+                    return@afterEvaluate
+                }
                 if (!hasRoutingAnnotateDependency()) {
                     // Automatically add the missing dependency to the implementation configuration
                     dependencies.add("implementation", "io.ktor:ktor-server-routing-openapi:${KtorGradlePlugin.KTOR_VERSION}")
@@ -30,6 +45,26 @@ internal fun Project.configureOpenApi() {
             logger.warn("Could not apply compiler plugin. OpenAPI inference will not be available.")
         }
     }
+}
+
+/**
+ * Whether the currently applied Kotlin Gradle plugin is new enough to load the Ktor OpenAPI
+ * compiler plugin artifact. The compiler plugin uses Kotlin compiler internals that are only
+ * available starting from [KotlinVersion.V2_4_0].
+ */
+private fun Project.isOpenApiCompilerPluginSupported(): Boolean {
+    val rawVersion = try {
+        getKotlinPluginVersion()
+    } catch (_: Throwable) {
+        return false
+    }
+    val version = try {
+        KotlinVersion.parse(rawVersion)
+    } catch (_: Throwable) {
+        // If we can't parse the version, assume it's a recent enough development build.
+        return true
+    }
+    return version >= KotlinVersion.V2_4_0
 }
 
 private fun Project.hasRoutingAnnotateDependency(): Boolean {

--- a/plugin/src/main/kotlin/io/ktor/plugin/internal/KotlinVersion.kt
+++ b/plugin/src/main/kotlin/io/ktor/plugin/internal/KotlinVersion.kt
@@ -21,5 +21,6 @@ internal value class KotlinVersion(private val value: Int) : Comparable<KotlinVe
         }
 
         val V2_1_20 = KotlinVersion(2_1_20)
+        val V2_4_0 = KotlinVersion(2_4_00)
     }
 }

--- a/plugin/src/test/kotlin/io/ktor/plugin/PluginTest.kt
+++ b/plugin/src/test/kotlin/io/ktor/plugin/PluginTest.kt
@@ -1,8 +1,10 @@
 package io.ktor.plugin
 
 import io.ktor.plugin.KtorGradlePlugin.Companion.VERSION
+import io.ktor.plugin.features.CompilerPlugin
 import io.ktor.plugin.internal.*
 import org.gradle.api.plugins.ApplicationPlugin
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import kotlin.test.*
 import io.ktor.plugin.KtorGradlePlugin.Companion.VERSION as KTOR_VERSION
 
@@ -84,6 +86,23 @@ class PluginTest {
 
         evaluate()
         assertEquals("-Dio.ktor.development=false", application.applicationDefaultJvmArgs.single())
+    }
+
+    @Test
+    fun `compiler plugin is not applied on Kotlin older than 2_4_0`() {
+        // The test classpath uses a Kotlin Gradle plugin version below 2.4.0 (see TestConstants.kt
+        // and libs.versions.toml). The Ktor OpenAPI compiler plugin artifact requires Kotlin 2.4.0+
+        // and would fail with NoClassDefFoundError when loaded by an older compiler, so the Ktor
+        // Gradle plugin must NOT apply the CompilerPlugin support plugin in this case.
+        val kotlinVersion = io.ktor.plugin.internal.KotlinVersion.parse(project.getKotlinPluginVersion())
+        assertTrue(
+            kotlinVersion < io.ktor.plugin.internal.KotlinVersion.V2_4_0,
+            "Test precondition: this test must run with Kotlin < 2.4.0, but got $kotlinVersion"
+        )
+        assertFalse(
+            project.plugins.hasPlugin(CompilerPlugin::class.java),
+            "CompilerPlugin must not be applied on Kotlin versions older than 2.4.0"
+        )
     }
 
     @Test


### PR DESCRIPTION
It seems that adding support for Kotlin 2.4.0 has removed support for all previous versions.

I'll look at a better fix in the compiler plugin for the next patch, but for now anyone using the OpenAPI code generation will need to use Kotlin 2.4.0 😞 